### PR TITLE
Add OpenAI-compatible TTS engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ A smart voice notification plugin for [OpenCode](https://opencode.ai) with **mul
 ### Smart TTS Engine Selection
 The plugin automatically tries multiple TTS engines in order, falling back if one fails:
 
-1. **ElevenLabs** (Online) - High-quality, anime-like voices with natural expression
-2. **Edge TTS** (Free) - Microsoft's neural voices, native Node.js implementation (no Python required)
-3. **Windows SAPI** (Offline) - Built-in Windows speech synthesis
-4. **Local Sound Files** (Fallback) - Plays bundled MP3 files if all TTS fails
+1. **OpenAI-Compatible** (Self-hosted) - Any OpenAI-compatible `/v1/audio/speech` endpoint (Kokoro, LocalAI, Coqui, AllTalk, etc.)
+2. **ElevenLabs** (Online) - High-quality, anime-like voices with natural expression
+3. **Edge TTS** (Free) - Microsoft's neural voices, native Node.js implementation (no Python required)
+4. **Windows SAPI** (Offline) - Built-in Windows speech synthesis
+5. **Local Sound Files** (Fallback) - Plays bundled MP3 files if all TTS fails
 
 ### Smart Notification System
 - **Sound-first mode**: Play a sound immediately, then speak a TTS reminder if user doesn't respond
@@ -118,13 +119,18 @@ If you prefer to create the config manually, add a `smart-voice-notify.jsonc` fi
     // Notification mode: 'sound-first', 'tts-first', 'both', 'sound-only'
     "notificationMode": "sound-first",
     
-    // TTS engine: 'elevenlabs', 'edge', 'sapi'
-    "ttsEngine": "elevenlabs",
+    // TTS engine: 'openai', 'elevenlabs', 'edge', 'sapi'
+    "ttsEngine": "openai",
     "enableTTS": true,
     
     // ElevenLabs settings (get API key from https://elevenlabs.io/app/settings/api-keys)
     "elevenLabsApiKey": "YOUR_API_KEY_HERE",
     "elevenLabsVoiceId": "cgSgspJ2msm6clMCkdW9",  // Jessica - Playful, Bright
+    
+    // OpenAI-compatible TTS (Kokoro, LocalAI, OpenAI, Coqui, AllTalk, etc.)
+    "openaiTtsEndpoint": "http://localhost:8880",
+    "openaiTtsVoice": "af_heart",
+    "openaiTtsModel": "kokoro",
     
     // Edge TTS settings (free, no API key required)
     "edgeVoice": "en-US-AnaNeural",
@@ -155,6 +161,30 @@ If you prefer to create the config manually, add a `smart-voice-notify.jsonc` fi
 ```
 
 For the complete configuration with all TTS engine settings, message arrays, AI prompts, and advanced options, see [`example.config.jsonc`](./example.config.jsonc) in the plugin directory.
+
+### OpenAI-Compatible TTS Setup (Kokoro, LocalAI, etc.)
+
+For self-hosted TTS using any OpenAI-compatible `/v1/audio/speech` endpoint:
+
+```jsonc
+{
+  "ttsEngine": "openai",
+  "openaiTtsEndpoint": "http://192.168.86.43:8880",  // Your TTS server
+  "openaiTtsVoice": "af_heart",                      // Server-dependent
+  "openaiTtsModel": "kokoro",                        // Server-dependent
+  "openaiTtsApiKey": "",                             // Optional, if server requires auth
+  "openaiTtsSpeed": 1.0                              // 0.25 to 4.0
+}
+```
+
+**Supported OpenAI-Compatible TTS Servers:**
+| Server | Example Endpoint | Voices |
+|--------|------------------|--------|
+| Kokoro | `http://localhost:8880` | `af_heart`, `af_bella`, `am_adam`, etc. |
+| LocalAI | `http://localhost:8080` | Model-dependent |
+| AllTalk | `http://localhost:7851` | Model-dependent |
+| OpenAI | `https://api.openai.com` | `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer` |
+| Coqui | `http://localhost:5002` | Model-dependent |
 
 ### AI Message Generation (Optional)
 
@@ -189,6 +219,11 @@ If you want dynamic, AI-generated notification messages instead of preset ones, 
 | Jan.ai | `http://localhost:1337/v1` | Required |
 
 ## Requirements
+
+### For OpenAI-Compatible TTS
+- Any server implementing the `/v1/audio/speech` endpoint
+- Examples: [Kokoro](https://github.com/remsky/Kokoro-FastAPI), [LocalAI](https://localai.io), [AllTalk](https://github.com/erew123/alltalk_tts), OpenAI API
+- No API key required for most self-hosted servers
 
 ### For ElevenLabs TTS
 - ElevenLabs API key (free tier: 10,000 characters/month)

--- a/util/config.js
+++ b/util/config.js
@@ -116,6 +116,12 @@ const getDefaultConfigObject = () => ({
   sapiRate: -1,
   sapiPitch: 'medium',
   sapiVolume: 'loud',
+  openaiTtsEndpoint: '',
+  openaiTtsApiKey: '',
+  openaiTtsModel: 'tts-1',
+  openaiTtsVoice: 'alloy',
+  openaiTtsFormat: 'mp3',
+  openaiTtsSpeed: 1.0,
   idleTTSMessages: [
     "All done! Your task has been completed successfully.",
     "Hey there! I finished working on your request.",
@@ -394,6 +400,37 @@ const generateDefaultConfig = (overrides = {}, version = '1.0.0') => {
     
     // Volume: 'silent', 'x-soft', 'soft', 'medium', 'loud', 'x-loud'
     "sapiVolume": "${overrides.sapiVolume || 'loud'}",
+    
+    // ============================================================
+    // OPENAI-COMPATIBLE TTS SETTINGS (Kokoro, LocalAI, OpenAI, etc.)
+    // ============================================================
+    // Any OpenAI-compatible /v1/audio/speech endpoint.
+    // Examples: Kokoro, OpenAI, LocalAI, Coqui, AllTalk, etc.
+    //
+    // To use OpenAI-compatible TTS:
+    // 1. Set ttsEngine above to "openai"
+    // 2. Set openaiTtsEndpoint to your server URL (without /v1/audio/speech)
+    // 3. Configure voice and model for your server
+    
+    // Base URL for your TTS server (e.g., "http://192.168.86.43:8880")
+    "openaiTtsEndpoint": "${overrides.openaiTtsEndpoint || ''}",
+    
+    // API key (leave empty if your server doesn't require auth)
+    "openaiTtsApiKey": "${overrides.openaiTtsApiKey || ''}",
+    
+    // Model name (server-dependent, e.g., "tts-1", "kokoro", "xtts")
+    "openaiTtsModel": "${overrides.openaiTtsModel || 'tts-1'}",
+    
+    // Voice name (server-dependent)
+    // Kokoro voices: "af_heart", "af_bella", "am_adam", etc.
+    // OpenAI voices: "alloy", "echo", "fable", "onyx", "nova", "shimmer"
+    "openaiTtsVoice": "${overrides.openaiTtsVoice || 'alloy'}",
+    
+    // Audio format: "mp3", "opus", "aac", "flac", "wav", "pcm"
+    "openaiTtsFormat": "${overrides.openaiTtsFormat || 'mp3'}",
+    
+    // Speech speed: 0.25 to 4.0 (1.0 = normal)
+    "openaiTtsSpeed": ${overrides.openaiTtsSpeed !== undefined ? overrides.openaiTtsSpeed : 1.0},
     
     // ============================================================
     // INITIAL TTS MESSAGES (Used immediately or after sound)


### PR DESCRIPTION
## Describe your changes

Adds support for any OpenAI-compatible `/v1/audio/speech` TTS endpoint, enabling self-hosted voice synthesis with:

- **Kokoro** - Fast local TTS
- **LocalAI** - Local AI inference
- **AllTalk** - Local TTS server
- **Coqui** - Neural TTS
- **OpenAI API** - Cloud TTS

### New config options:
- `openaiTtsEndpoint` - Base URL for TTS server
- `openaiTtsVoice` - Voice name (server-dependent)
- `openaiTtsModel` - Model name (server-dependent)
- `openaiTtsApiKey` - Optional auth token
- `openaiTtsSpeed` - Playback speed (0.25-4.0)
- `openaiTtsFormat` - Audio format (mp3, wav, etc.)

Set `ttsEngine: "openai"` to use. Falls back to Edge TTS if unavailable.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.