### PR TITLE
Added 60dB integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ The plugin automatically tries multiple TTS engines in order, falling back if on
 
 1. **OpenAI-Compatible** (Cloud/Self-hosted) - Any OpenAI-compatible `/v1/audio/speech` endpoint (Kokoro, LocalAI, Coqui, AllTalk, OpenAI API, etc.)
 2. **ElevenLabs** (Online) - High-quality, anime-like voices with natural expression
-3. **Edge TTS** (Free) - Microsoft's neural voices via Python CLI (recommended) or native npm fallback
-4. **Windows SAPI** (Offline) - Built-in Windows speech synthesis
-5. **macOS Say** (Offline) - Built-in macOS speech synthesis
-6. **Local Sound Files** (Fallback) - Plays bundled MP3 files if all TTS fails
+3. **60db** (Online) - High-quality cloned/professional voices via [60db.ai](https://60db.ai)
+4. **Edge TTS** (Free) - Microsoft's neural voices via Python CLI (recommended) or native npm fallback
+5. **Windows SAPI** (Offline) - Built-in Windows speech synthesis
+6. **macOS Say** (Offline) - Built-in macOS speech synthesis
+7. **Local Sound Files** (Fallback) - Plays bundled MP3 files if all TTS fails
 
 ### Smart Notification System
 - **Sound-first mode**: Play a sound immediately, then speak a TTS reminder if user doesn't respond
@@ -127,13 +128,18 @@ If you prefer to create the config manually, add a `smart-voice-notify.jsonc` fi
     // Notification mode: 'sound-first', 'tts-first', 'both', 'sound-only'
     "notificationMode": "sound-first",
     
-    // TTS engine: 'openai', 'elevenlabs', 'edge', 'sapi'
+    // TTS engine: 'openai', 'elevenlabs', '60db', 'edge', 'sapi'
     "ttsEngine": "openai",
     "enableTTS": true,
     
     // ElevenLabs settings (get API key from https://elevenlabs.io/app/settings/api-keys)
     "elevenLabsApiKey": "YOUR_API_KEY_HERE",
     "elevenLabsVoiceId": "cgSgspJ2msm6clMCkdW9",  // Jessica - Playful, Bright
+
+    // 60db settings (get API key from https://app.60db.ai)
+    // Note: stability/similarity use a 0-100 scale (ElevenLabs uses 0-1)
+    "sixtyDbApiKey": "YOUR_API_KEY_HERE",
+    "sixtyDbVoiceId": "fbb75ed2-975a-40c7-9e06-38e30524a9a1",
     
     // OpenAI-compatible TTS (Kokoro, LocalAI, OpenAI, Coqui, AllTalk, etc.)
     "openaiTtsEndpoint": "http://localhost:8880",
@@ -340,6 +346,12 @@ You can replace individual sound files with entire "Sound Themes" (like the clas
 - ElevenLabs API key (free tier: 10,000 characters/month)
 - Internet connection
 
+### For 60db TTS
+- 60db API key (get one from [app.60db.ai](https://app.60db.ai))
+- A voice ID (list yours via `GET https://api.60db.ai/myvoices`)
+- Internet connection
+- If 60db's quota/auth fails, the plugin automatically falls back to free Edge TTS
+
 ### For Edge TTS
 - Internet connection required
 - **Recommended**: Install Python edge-tts for best reliability: `pip install edge-tts`
@@ -501,6 +513,17 @@ When a user asks you to set up this plugin, follow these steps:
 }
 ```
 **Note**: User must get API key from https://elevenlabs.io/app/settings/api-keys
+
+#### Task: Enable 60db TTS
+```jsonc
+// In ~/.config/opencode/smart-voice-notify.jsonc
+{
+  "ttsEngine": "60db",
+  "sixtyDbApiKey": "USER_API_KEY_HERE",
+  "sixtyDbVoiceId": "fbb75ed2-975a-40c7-9e06-38e30524a9a1"
+}
+```
+**Note**: User must get an API key from https://app.60db.ai. Voice IDs can be listed via `GET https://api.60db.ai/myvoices`. Stability/similarity use a 0-100 scale.
 
 #### Task: Enable OpenAI-Compatible TTS (Kokoro, LocalAI, etc.)
 ```jsonc

--- a/example.config.jsonc
+++ b/example.config.jsonc
@@ -78,6 +78,7 @@
     // ============================================================
     // 'openai'     - OpenAI-compatible TTS (Self-hosted/Cloud, e.g. Kokoro, LocalAI)
     // 'elevenlabs' - Best quality, anime-like voices (requires API key, free tier: 10k chars/month)
+    // '60db'       - High quality cloned/professional voices via 60db.ai (requires API key)
     // 'edge'       - Good quality neural voices (Python edge-tts CLI RECOMMENDED, with msedge-tts npm fallback)
     // 'sapi'       - Windows built-in voices (free, offline, robotic)
     "ttsEngine": "elevenlabs",
@@ -107,7 +108,35 @@
     "elevenLabsStability": 0.5,       // Lower = more expressive, Higher = more consistent
     "elevenLabsSimilarity": 0.75,     // How closely to match the original voice
     "elevenLabsStyle": 0.5,           // Style exaggeration (higher = more expressive)
-    
+
+    // ============================================================
+    // 60db SETTINGS (High Quality - Cloned/Professional Voices)
+    // ============================================================
+    // Get your API key from: https://app.60db.ai
+    // Docs: https://docs.60db.ai
+    //
+    // To use 60db:
+    // 1. Uncomment sixtyDbApiKey and add your key
+    // 2. Change ttsEngine above to "60db"
+    //
+    // "sixtyDbApiKey": "YOUR_API_KEY_HERE",
+
+    // Voice ID (UUID). List your voices via GET https://api.60db.ai/myvoices
+    "sixtyDbVoiceId": "fbb75ed2-975a-40c7-9e06-38e30524a9a1",
+
+    // Voice tuning (NOTE: 0-100 scale, unlike ElevenLabs which is 0-1)
+    "sixtyDbStability": 50,           // Lower = more expressive, Higher = more consistent
+    "sixtyDbSimilarity": 75,          // How closely to match the source voice
+
+    // Speech speed: 0.5 to 2.0 (1.0 = normal)
+    "sixtyDbSpeed": 1.0,
+
+    // Audio enhancement (improves output quality)
+    "sixtyDbEnhance": true,
+
+    // Output format: "mp3", "wav", "ogg", "flac"
+    "sixtyDbOutputFormat": "mp3",
+
     // ============================================================
     // EDGE TTS SETTINGS (Free Neural Voices)
     // ============================================================

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,6 +1,6 @@
 export type NotificationMode = 'sound-first' | 'tts-first' | 'both' | 'sound-only';
 
-export type TTSEngine = 'openai' | 'elevenlabs' | 'edge' | 'sapi';
+export type TTSEngine = 'openai' | 'elevenlabs' | '60db' | 'edge' | 'sapi';
 
 export type NotificationEventType = 'idle' | 'permission' | 'question' | 'error';
 
@@ -11,6 +11,8 @@ export type SapiPitch = 'x-low' | 'low' | 'medium' | 'high' | 'x-high' | string;
 export type SapiVolume = 'silent' | 'x-soft' | 'soft' | 'medium' | 'loud' | 'x-loud' | string;
 
 export type OpenAITtsFormat = 'mp3' | 'opus' | 'aac' | 'flac' | 'wav' | 'pcm' | string;
+
+export type SixtyDbOutputFormat = 'mp3' | 'wav' | 'ogg' | 'flac' | string;
 
 export interface AIPrompts {
   idle: string;
@@ -71,6 +73,16 @@ export interface PluginConfig {
   elevenLabsStability: number;
   elevenLabsSimilarity: number;
   elevenLabsStyle: number;
+
+  // 60db TTS (https://docs.60db.ai)
+  sixtyDbApiKey?: string;
+  sixtyDbVoiceId: string;
+  sixtyDbStability: number;
+  sixtyDbSimilarity: number;
+  sixtyDbSpeed: number;
+  sixtyDbEnhance: boolean;
+  sixtyDbOutputFormat: SixtyDbOutputFormat;
+
   edgeVoice: string;
   edgePitch: string;
   edgeRate: string;

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -151,6 +151,13 @@ export const getDefaultConfigObject = (): PluginConfig => ({
   elevenLabsStability: 0.5,
   elevenLabsSimilarity: 0.75,
   elevenLabsStyle: 0.5,
+  // sixtyDbApiKey is intentionally omitted - users must set it
+  sixtyDbVoiceId: 'fbb75ed2-975a-40c7-9e06-38e30524a9a1',
+  sixtyDbStability: 50,
+  sixtyDbSimilarity: 75,
+  sixtyDbSpeed: 1.0,
+  sixtyDbEnhance: true,
+  sixtyDbOutputFormat: 'mp3',
   edgeVoice: 'en-US-JennyNeural',
   edgePitch: '+0Hz',
   edgeRate: '+10%',
@@ -451,6 +458,7 @@ const generateDefaultConfig = (overrides: Partial<PluginConfig> = {}, version = 
     // ============================================================
     // 'openai'     - OpenAI-compatible TTS (Self-hosted/Cloud, e.g. Kokoro, LocalAI)
     // 'elevenlabs' - Best quality, anime-like voices (requires API key, free tier: 10k chars/month)
+    // '60db'       - High quality cloned/professional voices via 60db.ai (requires API key)
     // 'edge'       - Good quality neural voices (Python edge-tts CLI RECOMMENDED, with msedge-tts npm fallback)
     // 'sapi'       - Windows built-in voices (free, offline, robotic)
     "ttsEngine": "${overrides.ttsEngine || 'elevenlabs'}",
@@ -485,7 +493,35 @@ const generateDefaultConfig = (overrides: Partial<PluginConfig> = {}, version = 
     "elevenLabsStability": ${overrides.elevenLabsStability !== undefined ? overrides.elevenLabsStability : 0.5},       // Lower = more expressive, Higher = more consistent
     "elevenLabsSimilarity": ${overrides.elevenLabsSimilarity !== undefined ? overrides.elevenLabsSimilarity : 0.75},     // How closely to match the original voice
     "elevenLabsStyle": ${overrides.elevenLabsStyle !== undefined ? overrides.elevenLabsStyle : 0.5},           // Style exaggeration (higher = more expressive)
-    
+
+    // ============================================================
+    // 60db SETTINGS (High Quality - Cloned/Professional Voices)
+    // ============================================================
+    // Get your API key from: https://app.60db.ai
+    // Docs: https://docs.60db.ai
+    //
+    // To use 60db:
+    // 1. Uncomment sixtyDbApiKey and add your key
+    // 2. Change ttsEngine above to "60db"
+    //
+    ${overrides.sixtyDbApiKey ? `"sixtyDbApiKey": "${overrides.sixtyDbApiKey}",` : `// "sixtyDbApiKey": "YOUR_API_KEY_HERE",`}
+
+    // Voice ID (UUID). List your voices via GET https://api.60db.ai/myvoices
+    "sixtyDbVoiceId": "${overrides.sixtyDbVoiceId || 'fbb75ed2-975a-40c7-9e06-38e30524a9a1'}",
+
+    // Voice tuning (NOTE: 0-100 scale, unlike ElevenLabs which is 0-1)
+    "sixtyDbStability": ${overrides.sixtyDbStability !== undefined ? overrides.sixtyDbStability : 50},        // Lower = more expressive, Higher = more consistent
+    "sixtyDbSimilarity": ${overrides.sixtyDbSimilarity !== undefined ? overrides.sixtyDbSimilarity : 75},      // How closely to match the source voice
+
+    // Speech speed: 0.5 to 2.0 (1.0 = normal)
+    "sixtyDbSpeed": ${overrides.sixtyDbSpeed !== undefined ? overrides.sixtyDbSpeed : 1.0},
+
+    // Audio enhancement (improves output quality)
+    "sixtyDbEnhance": ${overrides.sixtyDbEnhance !== undefined ? overrides.sixtyDbEnhance : true},
+
+    // Output format: "mp3", "wav", "ogg", "flac"
+    "sixtyDbOutputFormat": "${overrides.sixtyDbOutputFormat || 'mp3'}",
+
     // ============================================================
     // EDGE TTS SETTINGS (Free Neural Voices)
     // ============================================================

--- a/src/util/tts.ts
+++ b/src/util/tts.ts
@@ -72,6 +72,17 @@ export const getTTSConfig = (): PluginConfig => {
     elevenLabsStability: 0.5,
     elevenLabsSimilarity: 0.75,
     elevenLabsStyle: 0.5,
+
+    // 60db TTS settings (get API key from https://app.60db.ai)
+    // Note: 60db stability/similarity are 0-100 (ElevenLabs uses 0-1)
+    sixtyDbApiKey: '',
+    sixtyDbVoiceId: 'fbb75ed2-975a-40c7-9e06-38e30524a9a1',
+    sixtyDbStability: 50,
+    sixtyDbSimilarity: 75,
+    sixtyDbSpeed: 1.0,
+    sixtyDbEnhance: true,
+    sixtyDbOutputFormat: 'mp3',
+
     edgeVoice: 'en-US-JennyNeural',
     edgePitch: '+0Hz',
     edgeRate: '+10%',
@@ -231,6 +242,7 @@ export const getTTSConfig = (): PluginConfig => {
 };
 
 let elevenLabsQuotaExceeded = false;
+let sixtyDbQuotaExceeded = false;
 
 /**
  * Creates a TTS utility instance
@@ -386,6 +398,79 @@ export const createTTS = ({ $, client }: TTSFactoryParams): TTSAPI => {
         await showToast('⚠️ ElevenLabs quota exceeded! Switching to Edge TTS for this session.', 'error');
       }
 
+      return false;
+    }
+  };
+
+  /**
+   * 60db Engine (Online, High Quality, cloned/professional voices)
+   * Calls the non-streaming /tts-synthesize endpoint, which returns
+   * base64-encoded audio in a JSON envelope. See https://docs.60db.ai
+   */
+  const speakWith60db = async (text: string): Promise<boolean> => {
+    if (sixtyDbQuotaExceeded) return false;
+
+    if (!config.sixtyDbApiKey) {
+      debugLog('speakWith60db: No API key configured');
+      return false;
+    }
+
+    try {
+      const outputFormat = config.sixtyDbOutputFormat || 'mp3';
+      const body = {
+        text,
+        voice_id: config.sixtyDbVoiceId || 'fbb75ed2-975a-40c7-9e06-38e30524a9a1',
+        enhance: config.sixtyDbEnhance ?? true,
+        speed: config.sixtyDbSpeed ?? 1.0,
+        stability: config.sixtyDbStability ?? 50,
+        similarity: config.sixtyDbSimilarity ?? 75,
+        output_format: outputFormat,
+      };
+
+      debugLog(`speakWith60db: Calling /tts-synthesize with voice=${body.voice_id}, format=${outputFormat}`);
+
+      const response = await fetch('https://api.60db.ai/tts-synthesize', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${config.sixtyDbApiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        debugLog(`speakWith60db: API error ${response.status}: ${errorText}`);
+
+        // Quota / auth failures: disable for the session and fall back
+        if (response.status === 401 || response.status === 402 || response.status === 429) {
+          sixtyDbQuotaExceeded = true;
+          await showToast('⚠️ 60db quota/auth error! Switching to Edge TTS for this session.', 'error');
+        }
+        return false;
+      }
+
+      const data = (await response.json()) as {
+        success?: boolean;
+        message?: string;
+        audio_base64?: string;
+      };
+
+      if (!data.success || !data.audio_base64) {
+        debugLog(`speakWith60db: API returned no audio (${data.message ?? 'unknown reason'})`);
+        return false;
+      }
+
+      const tempFile = path.join(os.tmpdir(), `opencode-tts-60db-${Date.now()}.${outputFormat}`);
+      fs.writeFileSync(tempFile, Buffer.from(data.audio_base64, 'base64'));
+
+      await playAudioFile(tempFile);
+      try {
+        fs.unlinkSync(tempFile);
+      } catch {}
+      return true;
+    } catch (error) {
+      debugLog(`speakWith60db error: ${getErrorMessage(error) || String(error) || 'Unknown error'}`);
       return false;
     }
   };
@@ -748,6 +833,11 @@ public static extern int waveOutGetVolume(IntPtr hwo, out uint dwVolume);
         if (!success) success = await speakWithSay(message); // macOS fallback
       } else if (engine === 'elevenlabs') {
         success = await speakWithElevenLabs(message);
+        if (!success) success = await speakWithEdgeTTS(message);
+        if (!success) success = await speakWithSAPI(message);
+        if (!success) success = await speakWithSay(message); // macOS fallback
+      } else if (engine === '60db') {
+        success = await speakWith60db(message);
         if (!success) success = await speakWithEdgeTTS(message);
         if (!success) success = await speakWithSAPI(message);
         if (!success) success = await speakWithSay(message); // macOS fallback

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -8,6 +8,10 @@ TEST_ELEVENLABS_API_KEY=your-api-key-here
 TEST_ELEVENLABS_VOICE_ID=your-voice-id-here
 TEST_ELEVENLABS_MODEL=eleven_turbo_v2_5
 
+# --- 60db TTS (High-quality cloned/professional voices) ---
+TEST_60DB_API_KEY=your-api-key-here
+TEST_60DB_VOICE_ID=fbb75ed2-975a-40c7-9e06-38e30524a9a1
+
 # --- OpenAI-Compatible TTS (ElectronHub/Kokoro) ---
 TEST_OPENAI_TTS_ENDPOINT=https://api.example.com
 TEST_OPENAI_TTS_API_KEY=your-api-key-here

--- a/tests/integration/60db.test.ts
+++ b/tests/integration/60db.test.ts
@@ -1,0 +1,66 @@
+// @ts-nocheck
+import { test, describe, expect, beforeAll, afterAll } from 'bun:test';
+import { createTTS } from '../../src/util/tts.js';
+import { createMockShellRunner, createMockClient, createTestTempDir, cleanupTestTempDir, createTestConfig } from '../setup.js';
+
+const has60dbKey = !!process.env.TEST_60DB_API_KEY && process.env.TEST_60DB_API_KEY !== 'your-api-key-here';
+
+describe.skipIf(!has60dbKey)('60db Integration', () => {
+  let tempDir;
+  let mockShell;
+  let mockClient;
+
+  beforeAll(() => {
+    tempDir = createTestTempDir();
+    mockShell = createMockShellRunner();
+    mockClient = createMockClient();
+
+    // Create config with real credentials from env
+    createTestConfig({
+      ttsEngine: '60db',
+      sixtyDbApiKey: process.env.TEST_60DB_API_KEY,
+      sixtyDbVoiceId: process.env.TEST_60DB_VOICE_ID || 'fbb75ed2-975a-40c7-9e06-38e30524a9a1',
+      enableTTS: true,
+      debugLog: true,
+    });
+  });
+
+  afterAll(() => {
+    cleanupTestTempDir();
+  });
+
+  test('should generate and play speech using real 60db API', async () => {
+    const tts = createTTS({ $: mockShell, client: mockClient });
+
+    // We expect this to call the 60db API, write a temp file, and play it
+    const success = await tts.speak('This is a real integration test for 60db.');
+
+    expect(success).toBe(true);
+
+    // Verify that playAudioFile was called (via mockShell)
+    expect(mockShell.getCallCount()).toBeGreaterThan(0);
+
+    const lastCall = mockShell.getLastCall();
+    if (process.platform === 'win32') {
+      expect(lastCall.command).toContain('powershell.exe');
+      expect(lastCall.command).toContain('MediaPlayer');
+    } else if (process.platform === 'darwin') {
+      expect(lastCall.command).toContain('afplay');
+    }
+  }, 30000); // 30s timeout for API call
+
+  test('should handle invalid API key gracefully', async () => {
+    // Rewrite the config file with an invalid key (createTTS loads from file)
+    createTestConfig({
+      ttsEngine: '60db',
+      sixtyDbApiKey: 'invalid-key',
+      enableTTS: true,
+    });
+
+    const tts = createTTS({ $: mockShell, client: mockClient });
+    const success = await tts.speak('Testing invalid key.');
+
+    // Should fail 60db and fall back to Edge -> SAPI -> Say, or return false if all fail.
+    expect(success).toBeDefined();
+  }, 10000);
+});

--- a/tests/unit/tts.test.ts
+++ b/tests/unit/tts.test.ts
@@ -268,6 +268,89 @@ describe('tts.js', () => {
     });
   });
 
+  describe('speakWith60db()', () => {
+    let mockShell;
+    let mockClient;
+    let tts;
+    let originalFetch;
+
+    const okAudioResponse = () => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ success: true, audio_base64: Buffer.from('audio').toString('base64') }),
+    });
+
+    beforeEach(() => {
+      createTestTempDir();
+      mockShell = createMockShellRunner();
+      mockClient = createMockClient();
+      originalFetch = global.fetch;
+    });
+
+    afterEach(() => {
+      cleanupTestTempDir();
+      global.fetch = originalFetch;
+    });
+
+    it('should return false if no API key is configured', async () => {
+      createTestConfig({ sixtyDbApiKey: '', ttsEngine: '60db' });
+
+      // Make all fallbacks fail so the result reflects 60db's own outcome
+      mockEdgeTTSToFile.mockImplementation(() => Promise.reject(new Error('Edge failed')));
+      mockShell = createMockShellRunner({ handler: () => ({ exitCode: 1, stderr: 'SAPI failed' }) });
+      tts = createTTS({ $: mockShell, client: mockClient });
+
+      const success = await tts.speak('Hello', { ttsEngine: '60db' });
+      expect(success).toBe(false);
+    });
+
+    it('should POST to the 60db synthesize endpoint with a Bearer token', async () => {
+      createTestConfig({
+        sixtyDbApiKey: 'sk_live_123',
+        sixtyDbVoiceId: 'voice-abc',
+        ttsEngine: '60db',
+        enableTTS: true,
+        enableSound: true,
+      });
+      tts = createTTS({ $: mockShell, client: mockClient });
+
+      global.fetch = mock(okAudioResponse);
+
+      await tts.speak('Hello');
+
+      expect(global.fetch).toHaveBeenCalled();
+      const [url, options] = global.fetch.mock.calls[0];
+      expect(url).toBe('https://api.60db.ai/tts-synthesize');
+      expect(options.method).toBe('POST');
+      expect(options.headers['Authorization']).toBe('Bearer sk_live_123');
+      const body = JSON.parse(options.body);
+      expect(body.text).toBe('Hello');
+      expect(body.voice_id).toBe('voice-abc');
+    });
+
+    it('should fall back to Edge TTS when 60db returns 401 (quota/auth)', async () => {
+      createTestConfig({
+        sixtyDbApiKey: 'sk_live_123',
+        ttsEngine: '60db',
+        enableTTS: true,
+        enableSound: true,
+      });
+      tts = createTTS({ $: mockShell, client: mockClient });
+
+      global.fetch = mock(() => Promise.resolve({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('quota exceeded'),
+      }));
+
+      // Edge should succeed as the fallback
+      mockEdgeTTSToFile.mockImplementation(() => Promise.resolve({ audioFilePath: 'edge-tts.mp3' }));
+
+      const success = await tts.speak('Hello');
+      expect(global.fetch).toHaveBeenCalled();
+      expect(success).toBe(true);
+    });
+  });
+
   describe('speakWithElevenLabs()', () => {
     let mockShell;
     let mockClient;


### PR DESCRIPTION
We added 60db as a new TTS engine, alongside ElevenLabs:

  - src/util/tts.ts — new speakWith60db(): POSTs to https://api.60db.ai/tts-synthesize with a Bearer token, decodes the audio_base64  response → temp file → plays → cleans up. Added a session quota circuit-breaker (401/402/429 → toast + fall back to Edge), and    
  wired it into the cascade: 60db → Edge → SAPI → Say → sound.
  - src/types/config.ts — '60db' added to TTSEngine + new sixtyDb* config fields (0–100 scale).
  - src/util/config.ts — 60db defaults + documented section in the generated config.
  - example.config.jsonc, README.md, tests/.env.example — docs for the new engine.
  - Tests — 3 unit tests + a credential-gated integration test.

  To use: set "ttsEngine": "60db", "sixtyDbApiKey", and optionally "sixtyDbVoiceId".