### PR TITLE
Give Windows a more reliable .NET player with fallback to MCI

### DIFF
--- a/src/util/tts.ts
+++ b/src/util/tts.ts
@@ -69,7 +69,7 @@ export const getTTSConfig = (): PluginConfig => {
     ttsEngine: 'elevenlabs',
     enableTTS: true,
     elevenLabsApiKey: '',
-    elevenLabsVoiceIdelevenLabsVoiceId: 'aEO01A4wXwd1O8GPgGlF',
+    elevenLabsVoiceId: 'cgSgspJ2msm6clMCkdW9',
     elevenLabsModel: 'eleven_turbo_v2_5',
     elevenLabsStability: 0.5,
     elevenLabsSimilarity: 0.75,

--- a/src/util/tts.ts
+++ b/src/util/tts.ts
@@ -69,7 +69,7 @@ export const getTTSConfig = (): PluginConfig => {
     ttsEngine: 'elevenlabs',
     enableTTS: true,
     elevenLabsApiKey: '',
-    elevenLabsVoiceId: 'cgSgspJ2msm6clMCkdW9',
+    elevenLabsVoiceIdelevenLabsVoiceId: 'aEO01A4wXwd1O8GPgGlF',
     elevenLabsModel: 'eleven_turbo_v2_5',
     elevenLabsStability: 0.5,
     elevenLabsSimilarity: 0.75,
@@ -339,6 +339,10 @@ export const createTTS = ({ $, client }: TTSFactoryParams): TTSAPI => {
     return Math.max(1, Math.floor(value));
   };
 
+  /**
+   * Play an audio file using legacy Windows Media Center (MCI)
+   */
+
   const getWindowsMciPlaybackCommand = (audioPath: string, loopCount: number): string => {
     const safePath = escapePowerShellSingleQuotedString(audioPath);
     return `
@@ -374,15 +378,55 @@ exit 0
   };
 
   /**
+   * Play an audio file using .NET player
+   */
+
+  const getWindowsDotnetPlaybackCommand = (audioPath: string, loopCount: number): string => {
+    const safePath = escapePowerShellSingleQuotedString(audioPath);
+    return `
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName presentationCore
+$player = New-Object System.Windows.Media.MediaPlayer
+$filePath = (Resolve-Path "${safePath}").Path
+$player.Open($filePath)
+while ($player.NaturalDuration.HasTimeSpan -eq $false) {
+    Start-Sleep -Milliseconds 50
+}
+$durationSeconds = $player.NaturalDuration.TimeSpan.TotalSeconds
+$player.Play()
+Start-Sleep -Seconds $durationSeconds
+
+try {
+  for ($i = 1; $i -lt ${loopCount}; $i++) {
+    $player.Position = [System.TimeSpan]::Zero
+    $player.Play()
+    Start-Sleep -Seconds $durationSeconds
+  }
+} finally {
+  try { $player.Close() } catch {}
+}
+exit 0
+`;
+  };
+
+  /**
    * Play an audio file using system media player
    */
   const playAudioFile = async (filePath: string, loops = 1): Promise<void> => {
     const safeLoops = getSafeLoopCount(loops);
     try {
       if (currentPlatform === 'win32') {
-        const cmd = getWindowsMciPlaybackCommand(filePath, safeLoops);
-        await runPowerShellCommand(cmd);
-        debugLog(`playAudioFile: Windows MCI playback completed for ${filePath} (${safeLoops}x)`);
+        try {
+          debugLog('playAudioFile: attempting to playAudioFile via .NET');
+          const cmd = getWindowsDotnetPlaybackCommand(filePath, safeLoops);
+          await runPowerShellCommand(cmd);
+          debugLog(`playAudioFile: Windows .NET playback completed for ${filePath} (${safeLoops}x)`);
+        } catch (error) {
+          debugLog(`playAudioFile error: .NET failed ${getErrorMessage(error)} attempting MCI`);
+          const cmd = getWindowsMciPlaybackCommand(filePath, safeLoops);
+          await runPowerShellCommand(cmd);
+          debugLog(`playAudioFile: Windows MCI playback completed for ${filePath} (${safeLoops}x)`);
+        }
       } else if (currentPlatform === 'darwin') {
         if (!shell) {
           debugLog('playAudioFile: shell runner ($) not available for macOS playback');

--- a/tests/unit/tts.test.ts
+++ b/tests/unit/tts.test.ts
@@ -169,7 +169,7 @@ describe('tts.js', () => {
         await tts.playAudioFile('test.mp3');
         expect(mockShell.getCallCount()).toBe(1);
         expect(mockShell.getLastCall().command).toContain('powershell.exe');
-        expect(mockShell.getLastCall().command).toContain('mciSendString');
+        expect(mockShell.getLastCall().command).toContain('$player.Play');
         expect(mockShell.getLastCall().command).toContain('test.mp3');
       }
     });
@@ -192,7 +192,7 @@ describe('tts.js', () => {
         expect(mockExecFile).toHaveBeenCalledTimes(1);
         expect(mockExecFile.mock.calls[0][0]).toBe('powershell.exe');
         expect(mockExecFile.mock.calls[0][1]).toContain('-Command');
-        expect(mockExecFile.mock.calls[0][1].join(' ')).toContain('mciSendString');
+        expect(mockExecFile.mock.calls[0][1].join(' ')).toContain('$player.Play');
       }
     });
 
@@ -203,7 +203,7 @@ describe('tts.js', () => {
 
       expect(mockShell.getCallCount()).toBe(1);
       expect(mockShell.getLastCall().command).toContain('powershell.exe');
-      expect(mockShell.getLastCall().command).toContain('mciSendString');
+      expect(mockShell.getLastCall().command).toContain('$player.Play');
       expect(mockShell.getLastCall().command).toContain('-lt 2');
     });
 


### PR DESCRIPTION
- add a .NET play function with fallback to the old Mci method if it fails.

This plugin worked for a couple days then stopped making sound, after some experimenting with the Powershell script the best I could get was a 275 or worse 277 error. When I went looking for a solution I ran it past Google's chat AI and it came up with the suggestion to use .NET instead.

Made it fall back to the legacy Media Center/MCI method for redundancy, mainly in case someone doesn't have .NET.

During setup it gave me a bunch of warnings about vulnerable libraries, that was beyond the scope of my fix (getting audio to play again). If I get the time to learn typescript I might give it a go later.

Thanks for the voices!